### PR TITLE
Split catalog entities into separate modules

### DIFF
--- a/domain/models/entities/Categoria.py
+++ b/domain/models/entities/Categoria.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class Categoria(BaseModel):
+    categoria_id: int
+    nombre: str
+    descripcion: str | None = None
+    estado: bool
+    fecha_creacion: datetime | None = None
+    fecha_actualizacion: datetime | None = None
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/MovimientosStock.py
+++ b/domain/models/entities/MovimientosStock.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class MovimientosStock(BaseModel):
+    movimiento_id: int
+    stock_id: int
+    producto_id: int
+    tipo_movimiento_id: int
+    ref_movimiento_id: int
+    cantidad: int
+    referencia_doc: str | None = None
+    nota: str | None = None
+    fecha_creacion: datetime | None = None
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/RefMovimiento.py
+++ b/domain/models/entities/RefMovimiento.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class RefMovimiento(BaseModel):
+    ref_movimiento_id: int
+    nombre: str
+    descripcion: str | None = None
+    activo: bool
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/Stock.py
+++ b/domain/models/entities/Stock.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class Stock(BaseModel):
+    stock_id: int
+    producto_id: int
+    cantidad_actual: int
+    cantidad_minima: int
+    ultima_actualizacion: datetime | None = None
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/TipoMovimiento.py
+++ b/domain/models/entities/TipoMovimiento.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class TipoMovimiento(BaseModel):
+    tipo_movimiento_id: int
+    nombre: str
+    descripcion: str | None = None
+    activo: bool
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/User.py
+++ b/domain/models/entities/User.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from .UserRole import UserRole
+
+
+class User(BaseModel):
+    user_id: int
+    correo: str
+    nombre_completo: str | None = None
+    contrasena_hash: str
+    role: UserRole
+    activo: bool
+    creado_at: datetime | None = None
+    actualizado_at: datetime | None = None
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/UserRole.py
+++ b/domain/models/entities/UserRole.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class UserRole(str, Enum):
+    administrador = "administrador"
+    vendedor = "vendedor"

--- a/domain/models/entities/__init__.py
+++ b/domain/models/entities/__init__.py
@@ -1,0 +1,17 @@
+from .UserRole import UserRole
+from .User import User
+from .Categoria import Categoria
+from .Stock import Stock
+from .TipoMovimiento import TipoMovimiento
+from .RefMovimiento import RefMovimiento
+from .MovimientosStock import MovimientosStock
+
+__all__ = [
+    "UserRole",
+    "User",
+    "Categoria",
+    "Stock",
+    "TipoMovimiento",
+    "RefMovimiento",
+    "MovimientosStock",
+]


### PR DESCRIPTION
## Summary
- split catalog-related domain entities into dedicated modules named after each class
- expose the individual entities from the entities package for convenient imports

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'domain')*


------
https://chatgpt.com/codex/tasks/task_e_68bf5fe5a118832dbd196b24a6ffa35f