### PR TITLE
Add ingresos SQLAlchemy model and Pydantic entity

### DIFF
--- a/domain/models/entities/Ingreso.py
+++ b/domain/models/entities/Ingreso.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class Ingreso(BaseModel):
+    ingreso_id: int
+    monto: Decimal
+    categoria_id: int | None = None
+    fecha: datetime
+    notas: str | None = None
+    cliente: str | None = None
+    tipo_ingreso: str
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/__init__.py
+++ b/domain/models/entities/__init__.py
@@ -2,6 +2,7 @@ from .UserRole import UserRole
 from .User import User
 from .Categoria import Categoria
 from .Stock import Stock
+from .Ingreso import Ingreso
 from .TipoMovimiento import TipoMovimiento
 from .RefMovimiento import RefMovimiento
 from .MovimientosStock import MovimientosStock
@@ -14,4 +15,5 @@ __all__ = [
     "TipoMovimiento",
     "RefMovimiento",
     "MovimientosStock",
+    "Ingreso",
 ]

--- a/infrastructure/database/models.py
+++ b/infrastructure/database/models.py
@@ -9,6 +9,7 @@ Base = declarative_base()
 
 # --- Enums ---
 UserRole = Enum('administrador', 'vendedor', name='user_role')
+TipoIngresoEnum = Enum('efectivo', 'transferencia', name='tipo_ingreso_enum')
 
 # --- Usuario ---
 class User(Base):
@@ -56,6 +57,8 @@ class Categoria(Base):
     productos           = relationship("Product", back_populates="categoria")
     creado_por          = relationship("User", back_populates="categorias_creadas",   foreign_keys=[creado_por_id])
     actualizado_por     = relationship("User", back_populates="categorias_editadas",  foreign_keys=[actualizado_por_id])
+
+    ingresos            = relationship("Ingreso", back_populates="categoria")
 
 # --- Catálogo: Producto ---
 class Product(Base):
@@ -166,3 +169,17 @@ class MovimientosStock(Base):
     __table_args__ = (
         CheckConstraint('cantidad > 0', name='ck_mov_cantidad_pos'),
     )
+
+# --- Ingresos ---
+class Ingreso(Base):
+    __tablename__ = "ingreso"
+
+    ingreso_id       = Column(Integer, Identity(start=1, cycle=False), primary_key=True, index=True)
+    monto            = Column(Numeric(10, 2), nullable=False)
+    categoria_id     = Column(Integer, ForeignKey("categoria.categoria_id", ondelete="SET NULL"), nullable=True)
+    fecha            = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    notas            = Column(String(255), nullable=True)
+    cliente          = Column(String(150), nullable=True)
+    tipo_ingreso     = Column(TipoIngresoEnum, nullable=False)
+
+    categoria        = relationship("Categoria", back_populates="ingresos")


### PR DESCRIPTION
## Summary
- add a SQLAlchemy `Ingreso` table with amount, category, date, notes, client, and type fields
- register an enum for income types and relate incomes to categories
- expose the new income entity through the Pydantic models package

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'domain')*


------
https://chatgpt.com/codex/tasks/task_e_68e964e90c20832dbf30f05cde215eea