### PR TITLE
Add constraints to ingreso model

### DIFF
--- a/infrastructure/database/models.py
+++ b/infrastructure/database/models.py
@@ -177,9 +177,13 @@ class Ingreso(Base):
     ingreso_id       = Column(Integer, Identity(start=1, cycle=False), primary_key=True, index=True)
     monto            = Column(Numeric(10, 2), nullable=False)
     categoria_id     = Column(Integer, ForeignKey("categoria.categoria_id", ondelete="SET NULL"), nullable=True)
-    fecha            = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    fecha            = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
     notas            = Column(String(255), nullable=True)
     cliente          = Column(String(150), nullable=True)
-    tipo_ingreso     = Column(TipoIngresoEnum, nullable=False)
+    tipo_ingreso     = Column(TipoIngresoEnum, nullable=False, index=True)
 
     categoria        = relationship("Categoria", back_populates="ingresos")
+
+    __table_args__ = (
+        CheckConstraint('monto >= 0', name='ck_ingreso_monto_no_negativo'),
+    )


### PR DESCRIPTION
## Summary
- define the SQLAlchemy `Ingreso` model with the requested income fields and relationships
- add indexes for `fecha` and `tipo_ingreso` and guard against negative `monto` values with a check constraint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9680b2170832da24c196e12a9702f