### PR TITLE
Add Egreso SQLAlchemy model and entity

### DIFF
--- a/domain/models/entities/Egreso.py
+++ b/domain/models/entities/Egreso.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class Egreso(BaseModel):
+    egreso_id: int
+    monto: Decimal
+    categoria_id: int | None = None
+    fecha: datetime
+    notas: str | None = None
+    cliente: str | None = None
+    tipo_egreso: str
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/__init__.py
+++ b/domain/models/entities/__init__.py
@@ -3,6 +3,7 @@ from .User import User
 from .Categoria import Categoria
 from .Stock import Stock
 from .Ingreso import Ingreso
+from .Egreso import Egreso
 from .TipoMovimiento import TipoMovimiento
 from .RefMovimiento import RefMovimiento
 from .MovimientosStock import MovimientosStock
@@ -16,4 +17,5 @@ __all__ = [
     "RefMovimiento",
     "MovimientosStock",
     "Ingreso",
+    "Egreso",
 ]

--- a/infrastructure/database/models.py
+++ b/infrastructure/database/models.py
@@ -10,6 +10,7 @@ Base = declarative_base()
 # --- Enums ---
 UserRole = Enum('administrador', 'vendedor', name='user_role')
 TipoIngresoEnum = Enum('efectivo', 'transferencia', name='tipo_ingreso_enum')
+TipoEgresoEnum = Enum('efectivo', 'transferencia', name='tipo_egreso_enum')
 
 # --- Usuario ---
 class User(Base):
@@ -59,6 +60,7 @@ class Categoria(Base):
     actualizado_por     = relationship("User", back_populates="categorias_editadas",  foreign_keys=[actualizado_por_id])
 
     ingresos            = relationship("Ingreso", back_populates="categoria")
+    egresos             = relationship("Egreso", back_populates="categoria")
 
 # --- Catálogo: Producto ---
 class Product(Base):
@@ -186,4 +188,22 @@ class Ingreso(Base):
 
     __table_args__ = (
         CheckConstraint('monto >= 0', name='ck_ingreso_monto_no_negativo'),
+    )
+
+
+class Egreso(Base):
+    __tablename__ = "egreso"
+
+    egreso_id        = Column(Integer, Identity(start=1, cycle=False), primary_key=True, index=True)
+    monto            = Column(Numeric(10, 2), nullable=False)
+    categoria_id     = Column(Integer, ForeignKey("categoria.categoria_id", ondelete="SET NULL"), nullable=True)
+    fecha            = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
+    notas            = Column(String(255), nullable=True)
+    cliente          = Column(String(150), nullable=True)
+    tipo_egreso      = Column(TipoEgresoEnum, nullable=False, index=True)
+
+    categoria        = relationship("Categoria", back_populates="egresos")
+
+    __table_args__ = (
+        CheckConstraint('monto >= 0', name='ck_egreso_monto_no_negativo'),
     )


### PR DESCRIPTION
## Summary
- add a SQLAlchemy enum and table to persist egresos linked to categorías
- expose the egresos relationship on categorías and add the matching Pydantic entity export

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'domain')*


------
https://chatgpt.com/codex/tasks/task_e_68e96f5c0c18832d951c14d7455f0aba