### PR TITLE
Add cartera table and entity

### DIFF
--- a/domain/models/entities/Cartera.py
+++ b/domain/models/entities/Cartera.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class Cartera(BaseModel):
+    cartera_id: int
+    monto: Decimal
+    categoria_contabilidad_id: int | None = None
+    fecha: datetime
+    cliente: str | None = None
+    notas: str | None = None
+
+    class Config:
+        from_attributes = True

--- a/domain/models/entities/__init__.py
+++ b/domain/models/entities/__init__.py
@@ -8,6 +8,7 @@ from .Egreso import Egreso
 from .TipoMovimiento import TipoMovimiento
 from .RefMovimiento import RefMovimiento
 from .MovimientosStock import MovimientosStock
+from .Cartera import Cartera
 
 __all__ = [
     "UserRole",
@@ -20,4 +21,5 @@ __all__ = [
     "MovimientosStock",
     "Ingreso",
     "Egreso",
+    "Cartera",
 ]

--- a/infrastructure/database/models.py
+++ b/infrastructure/database/models.py
@@ -69,6 +69,7 @@ class CategoriaContabilidad(Base):
 
     ingresos            = relationship("Ingreso", back_populates="categoria_contabilidad")
     egresos             = relationship("Egreso", back_populates="categoria_contabilidad")
+    carteras            = relationship("Cartera", back_populates="categoria_contabilidad")
 
 # --- Catálogo: Producto ---
 class Product(Base):
@@ -214,4 +215,21 @@ class Egreso(Base):
 
     __table_args__ = (
         CheckConstraint('monto >= 0', name='ck_egreso_monto_no_negativo'),
+    )
+
+
+class Cartera(Base):
+    __tablename__ = "cartera"
+
+    cartera_id                = Column(Integer, Identity(start=1, cycle=False), primary_key=True, index=True)
+    monto                     = Column(Numeric(10, 2), nullable=False)
+    categoria_contabilidad_id = Column(Integer, ForeignKey("categoria_contabilidad.id", ondelete="SET NULL"), nullable=True)
+    fecha                     = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
+    cliente                   = Column(String(150), nullable=True)
+    notas                     = Column(String(255), nullable=True)
+
+    categoria_contabilidad    = relationship("CategoriaContabilidad", back_populates="carteras")
+
+    __table_args__ = (
+        CheckConstraint('monto >= 0', name='ck_cartera_monto_no_negativo'),
     )


### PR DESCRIPTION
## Summary
- add Cartera SQLAlchemy model with accounting category relationship and constraints
- expose new Cartera relationship on CategoriaContabilidad
- create Pydantic Cartera entity for domain usage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e974622038832d89642c5844f7717a