### PR TITLE
Add accounting category registration API stack

### DIFF
--- a/app/helpers/get_categoria_contabilidad_service.py
+++ b/app/helpers/get_categoria_contabilidad_service.py
@@ -1,0 +1,26 @@
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from config import get_db
+from domain.services.categoria_contabilidad_service import (
+    CategoriaContabilidadService,
+)
+from domain.services.interfaces.categoria_contabilidad_service import (
+    ICategoriaContabilidadService,
+)
+from infrastructure.repository.categoria_contabilidad_repository import (
+    CategoriaContabilidadRepository,
+)
+
+
+def get_categoria_contabilidad_service(
+    db: Session = Depends(get_db),
+) -> ICategoriaContabilidadService:
+    try:
+        repository = CategoriaContabilidadRepository(db)
+        return CategoriaContabilidadService(repository)
+    except Exception as exc:  # pragma: no cover - inicialización crítica
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"No se pudo inicializar el servicio de categorías contables: {exc}",
+        ) from exc

--- a/app/routes/categorias_contabilidad_router.py
+++ b/app/routes/categorias_contabilidad_router.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+from app.helpers.get_categoria_contabilidad_service import (
+    get_categoria_contabilidad_service,
+)
+from domain.schemas.categoria_contabilidad import (
+    CategoriaContabilidadCreate,
+    CategoriaContabilidadResponse,
+)
+from domain.services.interfaces.categoria_contabilidad_service import (
+    ICategoriaContabilidadService,
+)
+
+router = APIRouter(prefix="/categorias-contabilidad", tags=["categorias_contabilidad"])
+
+
+@router.post("", response_model=CategoriaContabilidadResponse, status_code=status.HTTP_201_CREATED)
+def registrar_categoria_contable(
+    payload: CategoriaContabilidadCreate,
+    service: ICategoriaContabilidadService = Depends(get_categoria_contabilidad_service),
+) -> CategoriaContabilidadResponse:
+    try:
+        categoria = service.registrar_categoria(payload)
+        return CategoriaContabilidadResponse.model_validate(categoria)
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se pudo registrar la categoría contable por un conflicto de integridad.",
+        ) from exc
+    except SQLAlchemyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error al persistir la categoría contable en la base de datos.",
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:  # pragma: no cover - error inesperado
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Ha ocurrido un error inesperado al registrar la categoría contable.",
+        ) from exc

--- a/domain/interfaces/categoria_contabilidad_repository.py
+++ b/domain/interfaces/categoria_contabilidad_repository.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.models.entities.CategoriaContabilidad import CategoriaContabilidad
+from domain.schemas.categoria_contabilidad import CategoriaContabilidadCreate
+
+
+class ICategoriaContabilidadRepository(Protocol):
+    """Contrato que debe cumplir cualquier repositorio de categorías contables."""
+
+    def create(
+        self, categoria: CategoriaContabilidadCreate
+    ) -> CategoriaContabilidad:
+        """Persiste una nueva categoría y devuelve la entidad resultante."""
+        ...

--- a/domain/schemas/categoria_contabilidad.py
+++ b/domain/schemas/categoria_contabilidad.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class CategoriaContabilidadCreate(BaseModel):
+    """Datos necesarios para registrar una categoría contable."""
+
+    nombre: str = Field(
+        ..., min_length=1, max_length=100, description="Nombre legible de la categoría"
+    )
+    codigo: str = Field(
+        ..., min_length=1, max_length=50, description="Código único de referencia"
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "nombre": "Ventas locales",
+                    "codigo": "VENT-LOC",
+                }
+            ]
+        }
+    }
+
+    @field_validator("nombre", "codigo")
+    @classmethod
+    def limpiar_cadena(cls, value: str) -> str:
+        limpio = value.strip()
+        if not limpio:
+            raise ValueError("El campo no puede estar vacío")
+        return limpio
+
+    @field_validator("codigo")
+    @classmethod
+    def normalizar_codigo(cls, value: str) -> str:
+        return value.upper()
+
+
+class CategoriaContabilidadResponse(BaseModel):
+    """Respuesta para operaciones relacionadas con categorías contables."""
+
+    id: int
+    nombre: str
+    codigo: str
+
+    model_config = {"from_attributes": True}

--- a/domain/services/categoria_contabilidad_service.py
+++ b/domain/services/categoria_contabilidad_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from domain.interfaces.categoria_contabilidad_repository import (
+    ICategoriaContabilidadRepository,
+)
+from domain.models.entities.CategoriaContabilidad import CategoriaContabilidad
+from domain.schemas.categoria_contabilidad import CategoriaContabilidadCreate
+from domain.services.interfaces.categoria_contabilidad_service import (
+    ICategoriaContabilidadService,
+)
+
+
+class CategoriaContabilidadService(ICategoriaContabilidadService):
+    """Servicio de dominio para la gestión de categorías contables."""
+
+    def __init__(self, repository: ICategoriaContabilidadRepository) -> None:
+        self._repository = repository
+
+    def registrar_categoria(
+        self, categoria: CategoriaContabilidadCreate
+    ) -> CategoriaContabilidad:
+        """Registra una categoría contable en el repositorio."""
+
+        return self._repository.create(categoria)

--- a/domain/services/interfaces/categoria_contabilidad_service.py
+++ b/domain/services/interfaces/categoria_contabilidad_service.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.models.entities.CategoriaContabilidad import CategoriaContabilidad
+from domain.schemas.categoria_contabilidad import CategoriaContabilidadCreate
+
+
+class ICategoriaContabilidadService(Protocol):
+    """Definición del servicio de categorías contables."""
+
+    def registrar_categoria(
+        self, categoria: CategoriaContabilidadCreate
+    ) -> CategoriaContabilidad:
+        ...

--- a/infrastructure/repository/categoria_contabilidad_repository.py
+++ b/infrastructure/repository/categoria_contabilidad_repository.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from domain.interfaces.categoria_contabilidad_repository import (
+    ICategoriaContabilidadRepository,
+)
+from domain.models.entities.CategoriaContabilidad import CategoriaContabilidad
+from domain.schemas.categoria_contabilidad import CategoriaContabilidadCreate
+from infrastructure.database.models import CategoriaContabilidad as CategoriaContabilidadDB
+
+
+class CategoriaContabilidadRepository(ICategoriaContabilidadRepository):
+    """Implementación de repositorio utilizando SQLAlchemy."""
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def create(
+        self, categoria: CategoriaContabilidadCreate
+    ) -> CategoriaContabilidad:
+        db_categoria = CategoriaContabilidadDB(
+            nombre=categoria.nombre,
+            codigo=categoria.codigo,
+        )
+
+        try:
+            self._db.add(db_categoria)
+            self._db.commit()
+            self._db.refresh(db_categoria)
+        except SQLAlchemyError as exc:  # pragma: no cover - manejo de errores DB
+            self._db.rollback()
+            raise exc
+
+        return CategoriaContabilidad.model_validate(db_categoria)

--- a/main.py
+++ b/main.py
@@ -8,8 +8,9 @@ import threading
 import time
 from fastapi.middleware.cors import CORSMiddleware
 from infrastructure.data.createTable import create_tables
-from app.routes import productos_router  # importa tu router
 from app.routes import ingresos_router
+from app.routes import productos_router  # importa tu router
+from app.routes import categorias_contabilidad_router
 from app.cargar_productos import cargar_productos_desde_xml
 
 app = FastAPI(
@@ -85,3 +86,4 @@ def read_root():
 # Incluir rutas
 app.include_router(productos_router.router)
 app.include_router(ingresos_router.router)
+app.include_router(categorias_contabilidad_router.router)

--- a/tests/test_categoria_contabilidad_service.py
+++ b/tests/test_categoria_contabilidad_service.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from domain.models.entities.CategoriaContabilidad import CategoriaContabilidad
+from domain.schemas.categoria_contabilidad import CategoriaContabilidadCreate
+from domain.services.categoria_contabilidad_service import (
+    CategoriaContabilidadService,
+)
+
+
+@pytest.fixture()
+def categoria_create() -> CategoriaContabilidadCreate:
+    return CategoriaContabilidadCreate(nombre="Ingresos varios", codigo="ing-var")
+
+
+@pytest.fixture()
+def categoria_entity() -> CategoriaContabilidad:
+    return CategoriaContabilidad(id=1, nombre="Ingresos varios", codigo="ING-VAR")
+
+
+def test_registrar_categoria_devuelve_entidad(
+    categoria_create: CategoriaContabilidadCreate,
+    categoria_entity: CategoriaContabilidad,
+) -> None:
+    repository = MagicMock()
+    repository.create.return_value = categoria_entity
+
+    service = CategoriaContabilidadService(repository)
+
+    result = service.registrar_categoria(categoria_create)
+
+    repository.create.assert_called_once_with(categoria_create)
+    assert isinstance(result, CategoriaContabilidad)
+    assert result.codigo == "ING-VAR"


### PR DESCRIPTION
## Summary
- add Pydantic schemas, repository contracts, and SQLAlchemy repository for accounting categories
- implement domain service, FastAPI dependency, and controller to register accounting categories
- expose the new router from the application and cover the service with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb0bc088fc832d9e6944e6e509971e