### PR TITLE
Add egresos and cartera registration endpoints

### DIFF
--- a/app/helpers/get_cartera_service.py
+++ b/app/helpers/get_cartera_service.py
@@ -1,0 +1,18 @@
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from config import get_db
+from domain.services.cartera_service import CarteraService
+from domain.services.interfaces.cartera_service import ICarteraService
+from infrastructure.repository.cartera_repository import CarteraRepository
+
+
+def get_cartera_service(db: Session = Depends(get_db)) -> ICarteraService:
+    try:
+        repository = CarteraRepository(db)
+        return CarteraService(repository)
+    except Exception as exc:  # pragma: no cover - inicialización crítica
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"No se pudo inicializar el servicio de cartera: {exc}",
+        ) from exc

--- a/app/helpers/get_egreso_service.py
+++ b/app/helpers/get_egreso_service.py
@@ -1,0 +1,18 @@
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from config import get_db
+from domain.services.egreso_service import EgresoService
+from domain.services.interfaces.egreso_service import IEgresoService
+from infrastructure.repository.egreso_repository import EgresoRepository
+
+
+def get_egreso_service(db: Session = Depends(get_db)) -> IEgresoService:
+    try:
+        repository = EgresoRepository(db)
+        return EgresoService(repository)
+    except Exception as exc:  # pragma: no cover - inicialización crítica
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"No se pudo inicializar el servicio de egresos: {exc}",
+        ) from exc

--- a/app/routes/cartera_router.py
+++ b/app/routes/cartera_router.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+from app.helpers.get_cartera_service import get_cartera_service
+from domain.schemas.cartera import CarteraCreate, CarteraResponse
+from domain.services.interfaces.cartera_service import ICarteraService
+
+router = APIRouter(prefix="/carteras", tags=["carteras"])
+
+
+@router.post("", response_model=CarteraResponse, status_code=status.HTTP_201_CREATED)
+def registrar_cartera(
+    payload: CarteraCreate,
+    service: ICarteraService = Depends(get_cartera_service),
+) -> CarteraResponse:
+    try:
+        cartera = service.registrar_cartera(payload)
+        return CarteraResponse.model_validate(cartera)
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"No se pudo registrar la cartera por un conflicto de integridad.{exc}",
+        ) from exc
+    except SQLAlchemyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error al persistir la cartera en la base de datos.{exc}",
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:  # pragma: no cover - error inesperado
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Ha ocurrido un error inesperado al registrar la cartera.",
+        ) from exc

--- a/app/routes/egresos_router.py
+++ b/app/routes/egresos_router.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+from app.helpers.get_egreso_service import get_egreso_service
+from domain.schemas.egreso import EgresoCreate, EgresoResponse
+from domain.services.interfaces.egreso_service import IEgresoService
+
+router = APIRouter(prefix="/egresos", tags=["egresos"])
+
+
+@router.post("", response_model=EgresoResponse, status_code=status.HTTP_201_CREATED)
+def registrar_egreso(
+    payload: EgresoCreate,
+    service: IEgresoService = Depends(get_egreso_service),
+) -> EgresoResponse:
+    try:
+        egreso = service.registrar_egreso(payload)
+        return EgresoResponse.model_validate(egreso)
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"No se pudo registrar el egreso por un conflicto de integridad.{exc}",
+        ) from exc
+    except SQLAlchemyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error al persistir el egreso en la base de datos.{exc}",
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:  # pragma: no cover - error inesperado
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Ha ocurrido un error inesperado al registrar el egreso.",
+        ) from exc

--- a/domain/interfaces/cartera_repository.py
+++ b/domain/interfaces/cartera_repository.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.models.entities.Cartera import Cartera
+from domain.schemas.cartera import CarteraCreate
+
+
+class ICarteraRepository(Protocol):
+    """Contrato para la persistencia de cuentas por cobrar (cartera)."""
+
+    def create(self, cartera: CarteraCreate) -> Cartera:
+        """Persiste un nuevo registro de cartera y devuelve la entidad resultante."""
+        ...

--- a/domain/interfaces/egreso_repository.py
+++ b/domain/interfaces/egreso_repository.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.models.entities.Egreso import Egreso
+from domain.schemas.egreso import EgresoCreate
+
+
+class IEgresoRepository(Protocol):
+    """Contrato para la persistencia de egresos."""
+
+    def create(self, egreso: EgresoCreate) -> Egreso:
+        """Persiste un nuevo egreso y devuelve la entidad resultante."""
+        ...

--- a/domain/schemas/cartera.py
+++ b/domain/schemas/cartera.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class CarteraCreate(BaseModel):
+    """Datos necesarios para registrar un movimiento de cartera."""
+
+    monto: Decimal = Field(..., gt=0, max_digits=10)
+    categoria_contabilidad_id: int | None = Field(
+        default=None,
+        gt=0,
+        description="Identificador de la categoría contable asociada a la cartera.",
+    )
+    fecha: datetime | None = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="Fecha del movimiento de cartera. Si no se envía se usa la hora actual en UTC.",
+    )
+    cliente: str | None = Field(
+        default=None,
+        max_length=150,
+        description="Nombre del cliente asociado a la cartera.",
+    )
+    notas: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Notas adicionales sobre el movimiento.",
+    )
+
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "monto": "200000.00",
+                    "categoria_contabilidad_id": 4,
+                    "fecha": "2024-01-11T10:00:00Z",
+                    "cliente": "Cliente ABC",
+                    "notas": "Saldo pendiente factura 456",
+                }
+            ]
+        },
+    }
+
+    @field_validator("monto")
+    @classmethod
+    def normalizar_monto(cls, value: Decimal) -> Decimal:
+        cuantizado = value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        if cuantizado <= 0:
+            raise ValueError("El monto debe ser mayor a cero")
+        return cuantizado
+
+    @field_validator("fecha")
+    @classmethod
+    def asegurar_timezone(cls, value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    @field_validator("notas", "cliente")
+    @classmethod
+    def limpiar_texto(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip() or None
+
+
+class CarteraResponse(BaseModel):
+    """Respuesta estándar para operaciones que devuelven una cartera."""
+
+    cartera_id: int
+    monto: Decimal
+    categoria_contabilidad_id: int | None = None
+    fecha: datetime
+    cliente: str | None = None
+    notas: str | None = None
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/domain/schemas/egreso.py
+++ b/domain/schemas/egreso.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+_ALLOWED_TIPO_EGRESO = ("efectivo", "transferencia")
+
+
+class EgresoCreate(BaseModel):
+    """Datos necesarios para registrar un egreso."""
+
+    monto: Decimal = Field(..., gt=0, max_digits=10)
+    categoria_contabilidad_id: int | None = Field(
+        default=None,
+        gt=0,
+        description="Identificador de la categoría contable asociada al egreso.",
+    )
+    fecha: datetime | None = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="Fecha del egreso. Si no se envía se usa la hora actual en UTC.",
+    )
+    notas: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Notas adicionales sobre el egreso.",
+    )
+    cliente: str | None = Field(
+        default=None,
+        max_length=150,
+        description="Nombre del proveedor u otra contraparte asociada al egreso.",
+    )
+    tipo_egreso: Literal["efectivo", "transferencia"] = Field(
+        ..., description="Medio por el cual se realizó el egreso."
+    )
+
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "monto": "50000.00",
+                    "categoria_contabilidad_id": 3,
+                    "fecha": "2024-01-10T15:30:00Z",
+                    "notas": "Pago de servicios",
+                    "cliente": "Proveedor XYZ",
+                    "tipo_egreso": "transferencia",
+                }
+            ]
+        },
+    }
+
+    @field_validator("monto")
+    @classmethod
+    def normalizar_monto(cls, value: Decimal) -> Decimal:
+        cuantizado = value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        if cuantizado <= 0:
+            raise ValueError("El monto debe ser mayor a cero")
+        return cuantizado
+
+    @field_validator("fecha")
+    @classmethod
+    def asegurar_timezone(cls, value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    @field_validator("tipo_egreso")
+    @classmethod
+    def validar_tipo_egreso(cls, value: str) -> str:
+        if value not in _ALLOWED_TIPO_EGRESO:
+            raise ValueError(
+                "Tipo de egreso inválido. Valores permitidos: 'efectivo' o 'transferencia'."
+            )
+        return value
+
+    @field_validator("notas", "cliente")
+    @classmethod
+    def limpiar_texto(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip() or None
+
+
+class EgresoResponse(BaseModel):
+    """Respuesta estándar para operaciones que devuelven un egreso."""
+
+    egreso_id: int
+    monto: Decimal
+    categoria_contabilidad_id: int | None = None
+    fecha: datetime
+    notas: str | None = None
+    cliente: str | None = None
+    tipo_egreso: str
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/domain/services/cartera_service.py
+++ b/domain/services/cartera_service.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from domain.interfaces.cartera_repository import ICarteraRepository
+from domain.models.entities.Cartera import Cartera
+from domain.schemas.cartera import CarteraCreate
+from domain.services.interfaces.cartera_service import ICarteraService
+
+
+class CarteraService(ICarteraService):
+    """Servicio de dominio para la gestión de cartera."""
+
+    def __init__(self, repository: ICarteraRepository) -> None:
+        self._repository = repository
+
+    def registrar_cartera(self, cartera: CarteraCreate) -> Cartera:
+        """Registra un movimiento de cartera aplicando las reglas del dominio."""
+        return self._repository.create(cartera)

--- a/domain/services/egreso_service.py
+++ b/domain/services/egreso_service.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from domain.interfaces.egreso_repository import IEgresoRepository
+from domain.models.entities.Egreso import Egreso
+from domain.schemas.egreso import EgresoCreate
+from domain.services.interfaces.egreso_service import IEgresoService
+
+
+class EgresoService(IEgresoService):
+    """Servicio de dominio para la gestión de egresos."""
+
+    def __init__(self, repository: IEgresoRepository) -> None:
+        self._repository = repository
+
+    def registrar_egreso(self, egreso: EgresoCreate) -> Egreso:
+        """Registra un egreso aplicando las reglas del dominio."""
+        return self._repository.create(egreso)

--- a/domain/services/interfaces/cartera_service.py
+++ b/domain/services/interfaces/cartera_service.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.models.entities.Cartera import Cartera
+from domain.schemas.cartera import CarteraCreate
+
+
+class ICarteraService(Protocol):
+    """Definición del servicio de cartera."""
+
+    def registrar_cartera(self, cartera: CarteraCreate) -> Cartera:
+        ...

--- a/domain/services/interfaces/egreso_service.py
+++ b/domain/services/interfaces/egreso_service.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from domain.models.entities.Egreso import Egreso
+from domain.schemas.egreso import EgresoCreate
+
+
+class IEgresoService(Protocol):
+    """Definición del servicio de egresos."""
+
+    def registrar_egreso(self, egreso: EgresoCreate) -> Egreso:
+        ...

--- a/infrastructure/repository/cartera_repository.py
+++ b/infrastructure/repository/cartera_repository.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from domain.interfaces.cartera_repository import ICarteraRepository
+from domain.models.entities.Cartera import Cartera
+from domain.schemas.cartera import CarteraCreate
+from infrastructure.database.models import Cartera as CarteraDB
+
+
+class CarteraRepository(ICarteraRepository):
+    """Implementación de repositorio de cartera utilizando SQLAlchemy."""
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def create(self, cartera: CarteraCreate) -> Cartera:
+        db_cartera = CarteraDB(
+            monto=cartera.monto,
+            categoria_contabilidad_id=cartera.categoria_contabilidad_id,
+            fecha=cartera.fecha,
+            cliente=cartera.cliente,
+            notas=cartera.notas,
+        )
+
+        try:
+            self._db.add(db_cartera)
+            self._db.commit()
+            self._db.refresh(db_cartera)
+        except SQLAlchemyError as exc:
+            self._db.rollback()
+            raise exc
+
+        return Cartera.model_validate(db_cartera)

--- a/infrastructure/repository/egreso_repository.py
+++ b/infrastructure/repository/egreso_repository.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from domain.interfaces.egreso_repository import IEgresoRepository
+from domain.models.entities.Egreso import Egreso
+from domain.schemas.egreso import EgresoCreate
+from infrastructure.database.models import Egreso as EgresoDB
+
+
+class EgresoRepository(IEgresoRepository):
+    """Implementación de repositorio de egresos utilizando SQLAlchemy."""
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def create(self, egreso: EgresoCreate) -> Egreso:
+        db_egreso = EgresoDB(
+            monto=egreso.monto,
+            categoria_contabilidad_id=egreso.categoria_contabilidad_id,
+            fecha=egreso.fecha,
+            notas=egreso.notas,
+            cliente=egreso.cliente,
+            tipo_egreso=egreso.tipo_egreso,
+        )
+
+        try:
+            self._db.add(db_egreso)
+            self._db.commit()
+            self._db.refresh(db_egreso)
+        except SQLAlchemyError as exc:
+            self._db.rollback()
+            raise exc
+
+        return Egreso.model_validate(db_egreso)

--- a/main.py
+++ b/main.py
@@ -1,95 +1,77 @@
 from fastapi import FastAPI
 from dotenv import load_dotenv
 import os
-from config import get_db
+from config import get_db  # noqa: F401  # Mantener import por compatibilidad
 import uvicorn
 import webbrowser
 import threading
 import time
 from fastapi.middleware.cors import CORSMiddleware
-from infrastructure.data.createTable import create_tables
-<<<<<<< HEAD
-from app.routes import productos_router  # importa tu router
-from app.routes import ingresos_router  # importa tu router
-#from app.cargar_productos import cargar_productos_desde_xml
-=======
-from app.routes import ingresos_router
-from app.routes import productos_router  # importa tu router
-from app.routes import categorias_contabilidad_router
-from app.cargar_productos import cargar_productos_desde_xml
->>>>>>> 085d489dc26a958e2c68cbdb6f75e127b98b4543
+from infrastructure.data.createTable import create_tables  # noqa: F401
+from app.routes import (
+    productos_router,
+    ingresos_router,
+    categorias_contabilidad_router,
+    egresos_router,
+    cartera_router,
+)
+from app.cargar_productos import cargar_productos_desde_xml  # noqa: F401
 
 app = FastAPI(
     title="POS API",
     version="1.0.0",
     description="API para gestión de productos con arquitectura limpia en python",
     root_path="/AutoServicioLite",
-    docs_url="/docs",  # Accesible desde /AutoServicioLite/docs
+    docs_url="/docs",
     redoc_url=None,
-    openapi_url="/openapi.json"
+    openapi_url="/openapi.json",
 )
 
-# Middleware opcional para CORS (útil si tienes frontend separado)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # en producción: ["https://tu-frontend.com"]
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-# Crear tablas al iniciar la aplicación
-#create_tables()
-
-#cargar_productos_desde_xml()
 
 @app.get("/")
 def root():
     return {"mensaje": "API POS en ejecución 🚀"}
 
+
 def open_chrome():
-    time.sleep(1)  # Espera a que el server arranque
+    time.sleep(1)
 
     url = "http://127.0.0.1:8000/docs"
 
-    # Intenta usar específicamente Google Chrome
     chrome_paths = [
         "C://Program Files//Google//Chrome//Application//chrome.exe",
         "C://Program Files (x86)//Google//Chrome//Application//chrome.exe",
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
         "/usr/bin/google-chrome",
-        "/usr/bin/chromium-browser"
+        "/usr/bin/chromium-browser",
     ]
 
     for path in chrome_paths:
         if os.path.exists(path):
-            webbrowser.register('chrome', None, webbrowser.BackgroundBrowser(path))
-            webbrowser.get('chrome').open_new(url)
+            webbrowser.register("chrome", None, webbrowser.BackgroundBrowser(path))
+            webbrowser.get("chrome").open_new(url)
             return
 
-    # Si no encuentra Chrome, abre con el navegador por defecto
     webbrowser.open_new(url)
+
 
 if __name__ == "__main__":
     threading.Thread(target=open_chrome).start()
     uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True)
 
-# Cargar el archivo correspondiente al entorno
 env = os.getenv("APP_ENV", "dev")
-load_dotenv(dotenv_path=f".env")
+load_dotenv(dotenv_path=".env")
 
-""" settings = get_db()
-app = FastAPI(title=settings.app_name, debug=settings.debug)
- """
-""" @app.get("/")
-def read_root():
-    return {
-        "app": settings.app_name,
-        "debug": settings.debug,
-        "env": settings.environment,
-    } """
-
-# Incluir rutas
-#app.include_router(productos_router.router)
+app.include_router(productos_router.router)
 app.include_router(ingresos_router.router)
+app.include_router(egresos_router.router)
+app.include_router(cartera_router.router)
 app.include_router(categorias_contabilidad_router.router)


### PR DESCRIPTION
## Summary
- add domain schemas, services, and repositories to support egreso and cartera records
- expose new FastAPI routes with helpers for registering egresos and cartera movements
- wire the new routers into the main application startup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb204ebf3c832da409ba9c8596ebcc